### PR TITLE
【マークアップ】商品詳細ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,4 @@
 @import "reset";
+@import "font-awesome-sprockets";
+@import "font-awesome";
+@import "modules/items.show";

--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -1,0 +1,253 @@
+.shows{
+  background-color:#f8f8f8 ;
+  display: -webkit-box;
+  font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+.show-link{
+  text-decoration: none;
+  color: #3CCACE;
+}
+  .show{
+    width: 700px;
+    margin: 40px auto;
+    height: 100%;
+
+
+    &__main{
+      padding:24px 40px 40px;
+      height: 100%;
+      background-color: white;
+
+      &__name{
+        text-align: center;
+        font-weight: bold;
+        font-size: 24px;
+      }
+
+      &__image{
+        margin: 16px 0 0;
+        height: 346px;
+        width: 100%;
+        object-fit: cover;
+      }
+
+      &__list{
+        display: flex;
+        height: 87px;
+        justify-content: center;
+        margin-top: 10px;
+      }
+
+      &__child{
+        width: 25%;
+        height: 100%;
+        margin: 0 10px 0 0;
+        &__image{
+          object-fit: cover;
+          height: 87px;
+          width: 100%;
+        }
+      }
+
+      &__box{
+        margin: 24px 0 24px;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        height: 77px;
+        &__price{
+          font-size: 46px;
+          font-weight: bold;
+          margin: 0 10px 0 0;
+        }
+        &__detail{
+          font-size: 16px;
+        }
+      }
+
+      &__explanation{
+        line-height: 1.5;
+        font-size: 18px;
+        margin: 30px 0;
+      }
+
+      &__table{
+        margin-bottom: 20px;
+        table{
+          width: 100%;
+          height: 375px;
+          border-collapse: collapse;
+          border: 1px solid #f8f8f8;
+
+          tbody{
+            display: table-row-group;
+            vertical-align: middle;
+            border-color: inherit;
+          
+            tr{
+              display: table-row;
+              vertical-align: inherit;
+              border-color: inherit;
+              th{
+                width: 20%;
+                background-color: #eee;
+                padding: 8px;
+                border: 1px solid #dedede;
+                font-size: 14px;
+                text-align: center;
+              }
+              td{
+                width: 61%;
+                padding: 15px 15px;
+                border: 1px solid #dedede;
+                font-size: 14px;
+              }
+            }
+          }  
+        }  
+      }
+
+      &__option{
+        display: flex;
+        justify-content: space-between;
+        height: 50px;
+        .favorite__link{
+          text-decoration: none;
+        }
+        .favorite__link:hover{
+          opacity: 0.5;
+        }
+        .show__favorite{
+          margin: 10px 0 0;
+          display: flex;
+          border-radius: 40px;
+          border: 1px solid #ffb340;
+          width: 135px;
+          align-items: center;
+          justify-content: center;
+          padding: 4px 8px;
+          &__child{
+            margin: 2px;
+          }
+        }
+        .optional__link:hover{
+          opacity: 0.5;
+        }
+        .show__optional{
+          margin: 10px 0 0;
+          display: flex;
+          border-radius: 4px;
+          color: #333;
+          border: 1px solid #333; 
+          padding: 6px 10px;
+          font-size: 14px;
+          justify-content: center;
+          align-items: center;
+          &__child{
+            margin: 2px;
+          }
+        }
+      }
+    }
+
+
+    &__middle{
+      padding: 24px;
+      background-color :white;
+      margin: 10px 0;
+      height: 270px;
+      text-align: center;
+
+      &__form{
+        .show__comment{
+          &__form{
+            width: 95%;
+            min-height: 104px;
+            padding: 10px; 
+          }
+          &__msg{
+            padding: 8px;
+            font-size: 14px;
+            background-color: #f8f8f8;
+            margin: 10px 0;
+            text-align: left;
+          }   
+          &__btn{
+            line-height: 48px;
+            background: #3CCACE;
+            border: 1px solid #3CCACE;
+            color: #fff;
+            width: 60%;
+            font-size: 18px;
+            border-radius: 100px;
+            margin-top: 10px;
+          }
+          &__icon{
+            color: white;
+            position: relative;
+            left: 140px;
+          }
+        }  
+      }
+    }
+
+
+    &__pagenation{
+      height: 24px;
+      display: flex;
+      justify-content: space-between;
+    }
+
+
+    &__bottom{
+      height:328px ;
+      margin-top: 20px;
+
+      &__msg{
+        margin: 24px 0 8px;
+        font-weight: bold;
+        font-size: 22px;
+      }
+
+      &__content{
+        float: left;
+        width: 32%;
+        margin: 24px 0 8px;
+        color: black;
+        text-decoration: none;
+        background-color: white;
+        font-weight: bold;
+        &-image{
+          width: 100%;
+          height: 150px;
+          object-fit: cover;
+        }
+        .content__row{
+          padding: 16px;
+          &-name{
+            line-height: 1.5;
+            font-size: 16px;
+          }
+          &-box{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+          }
+          &-fav{
+            display: flex;
+            &__icon{
+              margin-right: 5px;
+            }
+          }
+          &-tax{
+            font-size: 10px;
+          }
+        }
+      }
+      &__content:hover{
+        opacity: 0.5;
+      }
+    }
+  }
+}
+

--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -8,8 +8,9 @@
 }
   .show{
     width: 700px;
-    margin: 40px auto;
+    margin: 0 auto;
     height: 100%;
+    padding: 40px;
 
 
     &__main{
@@ -128,6 +129,9 @@
           &__child{
             margin: 2px;
           }
+        }
+        .optional__link{
+          text-decoration: none;
         }
         .optional__link:hover{
           opacity: 0.5;

--- a/app/assets/stylesheets/modules/_items.show.scss
+++ b/app/assets/stylesheets/modules/_items.show.scss
@@ -1,3 +1,4 @@
+
 .shows{
   background-color:#f8f8f8 ;
   display: -webkit-box;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
   def index
   end
+
+  def show
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -108,7 +108,7 @@
           ベビー ・ キッズをもっと見る
       = link_to "#", class: 'show-link' do    
         .show__bottom__content
-          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG",class:"show__bottom__content-image"}
+          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG", class: "show__bottom__content__image", alt: "商品イメージ"
           .content__row
             %h3.content__row-name
               ee

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,125 @@
+.shows
+  .show
+    .show__main
+      .show__main__name
+        product3
+      %img{class: "show__main__image",src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", alt: "商品画像"}
+      %ul.show__main__list
+        %li.show__main__child
+          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png",class:"show__main__child__image"}
+        %li.show__main__child
+          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png",class:"show__main__child__image"}
+        %li.show__main__child
+          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png",class:"show__main__child__image"}
+      .show__main__box
+        .show__main__box__price
+          ¥30000
+        .show__main__box__detail
+          (税込) 送料込み
+      .show__main__explanation
+        親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+      .show__main__table
+        %table
+          %tbody
+            %tr
+              %th
+                出品者
+              %td
+                hoge
+            %tr
+              %th
+                カテゴリー
+              %td
+                = link_to "#", class: 'category__link show-link' do
+                  ベビー・キッズ
+                %br
+                = link_to "#", class: 'category__link show-link' do
+                  ベビー服(男女兼用) ~95cm
+                %br
+                = link_to "#", class: 'category__link show-link' do
+                  アウター
+            %tr
+              %th
+                ブランド
+              %td
+            %tr
+              %th
+                商品のサイズ
+              %td
+            %tr
+              %th
+                商品の状態
+              %td
+                未使用に近い
+            %tr
+              %th
+                配送料の負担
+              %td
+                送料込み（出品者負担）
+            %tr
+              %th
+                発送元の地域
+              %td
+                = link_to "#", class: 'category__link show-link' do
+                  岩手県
+            %tr
+              %th
+                発送の目安
+              %td
+                4-7日で発送                        
+            
+      .show__main__option
+        = link_to "#", class:'favorite__link show-link' do
+          %ul.show__favorite
+            %li.show__favorite__child
+              = icon('fas','star', class:'show__favorite__icon')
+            %li.show__favorite__child
+              お気に入り
+            %li.show__favorite__child
+              0 
+        = link_to "#", class:'optional__link' do
+          %ul.show__optional
+            %li.show__optional__child 
+              = icon('fas', 'flag',class:'show__optional__icon') 
+            %li.show__optional__child
+              不適切な商品の報告
+    .show__middle
+      .show__middle__form
+        = form_with url:"#", class: 'show__comment' do |f|
+          = f.text_area :comment, class:'show__comment__form'
+          .show__comment__msg
+            相手のことを考え丁寧なコメントを心がけましょう。
+            %br
+            不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          = icon('fas','comment', class:'show__comment__icon')
+          = f.submit 'コメントする', class: 'show__comment__btn'     
+    .show__pagenation
+      = link_to "#", class: 'show-link' do
+        .show__pagenation__prev
+          = icon('fas','angle-left', class:'show__prev__icon')
+          前の商品
+      = link_to "#", class: 'show-link' do
+        .show__pagenation__next
+          後ろの商品
+          = icon('fas','angle-right', class:'show__next__icon')
+    .show__bottom
+      = link_to "#", class: 'show-link' do
+        .show__bottom__msg
+          ベビー ・ キッズをもっと見る
+      = link_to "#", class: 'show-link' do    
+        .show__bottom__content
+          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/16/IMG_9072.JPG",class:"show__bottom__content-image"}
+          .content__row
+            %h3.content__row-name
+              ee
+            .content__row-box 
+              %ul.content__row-box
+                %li.content__row-price
+                  1000円
+                %li.content__row-fav  
+                  .content__row-fav
+                    = icon('fas','star', class:'content__row-fav__icon')
+                  .content__row-count
+                    0     
+            .content__row-tax       
+              (税込)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -3,14 +3,14 @@
     .show__main
       .show__main__name
         product3
-      %img{class: "show__main__image",src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", alt: "商品画像"}
+      = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", class: "show__main__image", alt: "イメージ1"
       %ul.show__main__list
         %li.show__main__child
-          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png",class:"show__main__child__image"}
+          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", class: "show__main__child__image", alt: "イメージ2"  
         %li.show__main__child
-          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png",class:"show__main__child__image"}
+          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png", class: "show__main__child__image", alt: "イメージ3" 
         %li.show__main__child
-          %img{src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png",class:"show__main__child__image"}
+          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png", class: "show__main__child__image", alt: "イメージ4"
       .show__main__box
         .show__main__box__price
           ¥30000

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,3 +9,4 @@
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root 'items#index'
+  resources :items, only: [:index, :show]
 end


### PR DESCRIPTION
### WHAT
~~~
- 商品詳細ページのマークアップ haml scss bemを使用。

- show( __&box, __&middle, &__pagenation, &__bottom)の五つのブロックに分けて作成。

- scssの共通のスタイルはページ最上部に記載。

- tableのセレクタ指定は tr th td など直に指定しているので他のページにテーブルがあるなら適宜クラス名追加します。(スタイルの重複がないように。)

- リンクは今後実装しやすいように"link to do"で統一。

- imageはハリボテなのでhamlに直に記述。

~~~
### WHY
~~~
- 商品詳細のマークアップとサーバーサイドを担当しているため。
~~~
### Other
~~~
- ルーティング、コントローラーに詳細ページに遷移するように記述。

- stylesheets/application.scss にfont-awesomeを読み込むよう追記。
