### PR TITLE
【マークアップ】商品購入確認

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "modules/items.show";
+@import "modules/items.purchase";

--- a/app/assets/stylesheets/modules/_items.purchase.scss
+++ b/app/assets/stylesheets/modules/_items.purchase.scss
@@ -1,0 +1,242 @@
+* {
+  box-sizing: border-box;
+}
+
+.BuyWrapper{
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #f8f8f8;
+  font-family: "Arial","游ゴシック体","YuGothic","メイリオ","Meiryo","sans-serif";
+  
+  .Header{
+    -webkit-box-align: center;
+    align-items: center;
+    display: flex;
+    -webkit-box-pack: center;
+    justify-content: center;
+    height: 56px;
+  }
+
+  .ItemField{
+    max-width: 700px;
+    width: 100%;
+    margin: 0px auto;
+    .ItemInfo{
+      background-color: white;
+
+      .Contents:not(:first-child){
+        border-top: 1px solid #f8f8f8;
+      }
+
+      .Contents{
+        padding: 24px 16px;
+        max-width: 375px;
+        margin: 0px auto;
+
+        .BuySiteTitle{
+          text-align: center;
+          font-weight: 600;
+        }
+
+        .BuyItem{
+          display: flex;
+          justify-content: space-between;
+          
+          &__image{
+            height: 80px;
+            width: 80px;
+            border-radius: 4px;
+          }
+          &__Info{
+            width: 100%;
+            margin-left: 16px;
+      
+            &__Name{
+              font-size: 14px;
+              line-height: 1.4em;
+              margin-bottom: 8px;
+            }
+            &__Price{
+              text-align: right;
+              display: block;
+              margin: 0px;
+              padding: 0px;
+              border-width: 0px;
+              border-style: initial;
+              border-color: initial;
+              border-image: initial;
+              font: inherit;
+            }
+            .PriceDetail{
+              font-size: 12px;
+            }
+            .Price{
+              font-size: 15px;
+              font-weight: 600;
+              margin-left: 8px;
+            }
+          }
+        }
+
+        .PayPrice{
+          display: flex;
+          font-size: 18px;
+          font-weight: 600;
+          -webkit-box-pack: justify;
+          justify-content: space-between;
+          -webkit-box-align: center;
+          align-items: center;
+          .Price{
+            font-size: 24px;
+            font-family: Arial, Helvetica, sans-serif;
+          }
+        }
+  
+        .PayMethod{
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 16px;
+          h3{
+            font-size: 14px;
+            font-weight: 600;
+          }
+        }
+
+        .CardInfo{
+          p{
+            line-height: 1.4em;
+            font-size: 14px;
+          }
+          &__Logo{
+            .image{
+              margin-top: 8px;
+              max-height: 32px;
+              max-width: 48px;
+            }
+          }
+        }
+
+        .DeliveryAddress{
+          display: flex;
+          justify-content: space-between;
+          h3{
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 8px;
+          }
+        }
+      
+        .AddressInfo{
+          p{
+            line-height: 1.4rem;
+            font-size: 14px;
+          }
+        }
+        
+        .BuyBtn{
+          -webkit-box-align: center;
+          align-items: center;
+          background-color: rgb(234, 53, 45);
+          color: rgb(255, 255, 255);
+          cursor: pointer;
+          display: flex;
+          font-size: 14px;
+          font-weight: 600;
+          height: 50px;
+          -webkit-box-pack: center;
+          justify-content: center;
+          width: 100%;
+          -webkit-appearance: none;
+          border-width: initial;
+          border-style: none;
+          border-color: initial;
+          border-image: initial;
+          border-radius: 4px;
+          outline: none;
+          padding: 0px;
+          transition: all 0.3s ease-out 0s;
+        }
+
+        .GuideLink{
+          font-size: 14px;
+          align-items: center;
+          color: #0095ee;
+          cursor: pointer;
+          display: inline-flex;
+          line-height: 1.4em;
+          text-decoration: none;
+          word-break: normal;
+        }
+
+        .GuideLink:hover{
+          text-decoration: underline;
+          opacity: 0.5;
+        }
+      
+      }
+      
+      .Contents:last-of-type{
+        padding: 24px 16px 48px;
+      }
+
+
+    }
+  }
+
+  .Footer{
+    margin-top: auto;
+    text-align: center;
+    padding: 40px 0px 11px;
+
+    .Notice{
+      ul{
+        display: inline-block;
+        margin: -16px 0px 40px -16px;
+        font-size: 12px;
+
+        li{
+          display: block;
+          margin: 16px 0px 0px 16px;
+
+          .link{
+            font-size: 12px;
+            text-decoration: none;
+            color: inherit;
+          }
+        }
+      }
+    }
+
+    .Logo{
+      .CompanyName{
+        font-size: 12px;
+      }
+    }
+
+    li:hover{
+      text-decoration: underline;
+      opacity: 0.5;
+      }
+  }
+
+  @media(min-width: 768px){
+    .ResponsiveTitle{
+      font-size: 24px;
+      line-height: 34px;
+    }
+    .ResponsiveLogo{
+      height: 49px;
+      width: 185px;
+    }
+    .ResponsiveHeader{
+      height: 128px !important;
+    }
+  }
+  @media(max-width: 767px){
+    .ResponsiveTitle{
+      font-size: 17px;
+      line-height: 24px;
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,4 +4,7 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  def purchase
+  end
 end

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -1,0 +1,80 @@
+.BuyWrapper
+  .Header.ResponsiveHeader
+    = image_tag 'logo/logo.png',class:'ResponsiveLogo', alt:"FURIMA", height:"33px", width:"120px"
+  .ItemField
+    .ItemInfo
+      %section.Contents
+        %h2.BuySiteTitle.ResponsiveTitle
+          購入内容の確認
+      %section.Contents
+        .BuyItem
+          %img{class: "BuyItem__image",src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", alt: "商品画像"}
+          .BuyItem__Info
+            %p.BuyItem__Info__Name
+              冷凍パック 焼き魚定食
+            %p.BuyItem__Info__Price
+              %span.PriceDetail
+                送料込み (税込)
+              %span.Price
+                ¥1,700
+      %section.Contents
+        .PayPrice
+          %span
+            支払い金額
+          %span.Price
+            ¥1,700
+      %section.Contents
+        .PayMethod
+          %h3
+            支払い方法
+          %a.GuideLink{href:"#"}
+            変更する
+            %svg.style_right__2qI2e{"aria-hidden" => "true", :fill => "#0095ee", "fill-rule" => "evenodd", :height => "16", :viewbox => "0 0 24 24", :width => "16"}
+              %path{:d => "M9,19a.7.7,0,0,1-.49-.2.69.69,0,0,1,0-1l5.62-5.63a.28.28,0,0,0,.09-.21.27.27,0,0,0-.09-.2L8.6,6.19a.7.7,0,1,1,1-1l5.58,5.58A1.71,1.71,0,0,1,15.66,12a1.73,1.73,0,0,1-.49,1.2L9.54,18.8A.74.74,0,0,1,9,19Z"}
+
+        .CardInfo
+          %p
+            クレジットカード
+          %p
+            ************1111
+          %p
+            有効期限
+            14 / 24
+          %p.CardInfo__Logo
+            %img{class: "image",src:"https://web-jp-assets.mercdn.net/_next/static/images/mastercard-8b5b68c12b7a2fc8619c71f49ef9209b.svg", alt: "カード会社ロゴ"}
+      %section.Contents
+        .DeliveryAddress
+          %h3
+            配送先
+          %a.GuideLink{href:"#"}
+            変更する
+            %svg.style_right__2qI2e{"aria-hidden" => "true", :fill => "#0095ee", "fill-rule" => "evenodd", :height => "16", :viewbox => "0 0 24 24", :width => "16"}
+              %path{:d => "M9,19a.7.7,0,0,1-.49-.2.69.69,0,0,1,0-1l5.62-5.63a.28.28,0,0,0,.09-.21.27.27,0,0,0-.09-.2L8.6,6.19a.7.7,0,1,1,1-1l5.58,5.58A1.71,1.71,0,0,1,15.66,12a1.73,1.73,0,0,1-.49,1.2L9.54,18.8A.74.74,0,0,1,9,19Z"}
+
+        .AddressInfo
+          %p
+            〒123-4567
+          %p
+            東京都 板橋区 志村三丁目 20
+          %p
+            振魔 太郎
+      %section.Contents
+        .BuyBtn
+          購入する
+  .Footer
+    .Notice
+      %ul
+        %li
+          = link_to "#",class:"link" do
+            プライバシーポリシー
+        %li
+          = link_to "#",class:"link" do
+            FURIMA利用規約
+        %li
+          = link_to "#",class:"link" do
+            特定商取引に関する表記
+    .Logo
+      = link_to "#",class:"link" do
+        = image_tag 'logo/logo.png', alt:"FURIMA", height:"33px", width:"120px"
+      %p.CompanyName
+        ©︎ FURIMA, Inc.

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -8,7 +8,7 @@
           購入内容の確認
       %section.Contents
         .BuyItem
-          %img{class: "BuyItem__image",src:"https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", alt: "商品画像"}
+          = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png",class:"BuyItem__image", alt: "商品画像"
           .BuyItem__Info
             %p.BuyItem__Info__Name
               冷凍パック 焼き魚定食
@@ -27,7 +27,7 @@
         .PayMethod
           %h3
             支払い方法
-          %a.GuideLink{href:"#"}
+          = link_to '#', class:"GuideLink" do
             変更する
             %svg.style_right__2qI2e{"aria-hidden" => "true", :fill => "#0095ee", "fill-rule" => "evenodd", :height => "16", :viewbox => "0 0 24 24", :width => "16"}
               %path{:d => "M9,19a.7.7,0,0,1-.49-.2.69.69,0,0,1,0-1l5.62-5.63a.28.28,0,0,0,.09-.21.27.27,0,0,0-.09-.2L8.6,6.19a.7.7,0,1,1,1-1l5.58,5.58A1.71,1.71,0,0,1,15.66,12a1.73,1.73,0,0,1-.49,1.2L9.54,18.8A.74.74,0,0,1,9,19Z"}
@@ -41,12 +41,12 @@
             有効期限
             14 / 24
           %p.CardInfo__Logo
-            %img{class: "image",src:"https://web-jp-assets.mercdn.net/_next/static/images/mastercard-8b5b68c12b7a2fc8619c71f49ef9209b.svg", alt: "カード会社ロゴ"}
+            =image_tag "https://web-jp-assets.mercdn.net/_next/static/images/mastercard-8b5b68c12b7a2fc8619c71f49ef9209b.svg",class: "image", alt: "カード会社ロゴ"
       %section.Contents
         .DeliveryAddress
           %h3
             配送先
-          %a.GuideLink{href:"#"}
+          = link_to '#', class:"GuideLink" do
             変更する
             %svg.style_right__2qI2e{"aria-hidden" => "true", :fill => "#0095ee", "fill-rule" => "evenodd", :height => "16", :viewbox => "0 0 24 24", :width => "16"}
               %path{:d => "M9,19a.7.7,0,0,1-.49-.2.69.69,0,0,1,0-1l5.62-5.63a.28.28,0,0,0,.09-.21.27.27,0,0,0-.09-.2L8.6,6.19a.7.7,0,1,1,1-1l5.58,5.58A1.71,1.71,0,0,1,15.66,12a1.73,1.73,0,0,1-.49,1.2L9.54,18.8A.74.74,0,0,1,9,19Z"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   root 'items#index'
-  resources :items, only: [:index, :show]
+  resources :items, only: [:index, :show] do
+    member do
+      get 'purchase'
+    end
+  end
 end


### PR DESCRIPTION
# What
- 購入詳細画面の実装、ルーティング作成。
- BuyWrapperを画面全体とし、Header、ItemField、Footerの3つに分けて記載。
- 某フリマアプリ準拠のレスポンシブデザイン（ロゴとタイトルの縮小）を最下に記載。
- 画像と情報は現状埋め込み。

# Why
- 商品購入の根幹となる画面のため

# Other
- サーバを起動し、http://localhost:3000/items/1/purchase/ で画面をご確認ください。