### PR TITLE
【サーバーサイド】商品購入機能（単体テスト）

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -35,10 +35,14 @@ class CardsController < ApplicationController
   end
 
   def new
-    # 直打ちでcards/newに移動できないようにする（直打ちはrequest.referrer = nil）
-    previous_page2 = request.referrer
-    if previous_page2.blank?
-      redirect_to cards_path
+    if user_signed_in?
+      # 直打ちでcards/newに移動できないようにする（直打ちはrequest.referrer = nil）
+      previous_page2 = request.referrer
+      if previous_page2.blank?
+        redirect_to cards_path
+      end
+    else
+      redirect_to items_path
     end
   end
 
@@ -53,9 +57,7 @@ class CardsController < ApplicationController
       customer: card.customer_id, #支払うユーザのpayjp顧客ID
       currency: 'jpy', #通貨の指定
     )
-
-    @item_buyer = Item.find(params[:id])
-    @item_buyer.update( buyer_id: current_user.id)
+    
 
     redirect_to purchase_done_items_path
  
@@ -64,9 +66,8 @@ class CardsController < ApplicationController
   def create
     customer = Payjp::Customer.create(
       card: params['card_token'],
-      metadata: {user_id:current_user.id},
+      metadata: {user_id: current_user.id},
     )
-    
     @card = CreditCard.new(
       user_id: current_user.id,
       customer_id: customer.id,

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,34 +3,43 @@ class CardsController < ApplicationController
   Payjp.api_key = Rails.application.credentials.PAYJP[:PRIVATE_KEY]
   
   def index
-    @@previous_page2 = request.referrer
-    card = CreditCard.find_by(user_id: current_user.id)
-    if card.blank?
-      @default_card_information = nil
-    else
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @default_card_information = customer.cards.retrieve(card.card_id)
-      
-      @card_brand = @default_card_information.brand
-      case @card_brand
-      when "Visa"
-        @card_src = "cards/visa.png"
-      when "JCB"
-        @card_src = "cards/jcb.png"
-      when "MasterCard"
-        @card_src = "cards/master.png"
-      when "American Express"
-        @card_src = "cards/amex.png"
-      when "Diners Club"
-        @card_src = "cards/diners.png"
-      when "Discover"
-        @card_src = "cards/discover.png"
+    if user_signed_in?
+      # インデックスの直前のページ情報を取得
+      @@previous_page = request.referrer
+      card = CreditCard.find_by(user_id: current_user.id)
+      if card.blank?
+        @default_card_information = nil
+      else
+        customer = Payjp::Customer.retrieve(card.customer_id)
+        @default_card_information = customer.cards.retrieve(card.card_id)
+        
+        @card_brand = @default_card_information.brand
+        case @card_brand
+        when "Visa"
+          @card_src = "cards/visa.png"
+        when "JCB"
+          @card_src = "cards/jcb.png"
+        when "MasterCard"
+          @card_src = "cards/master.png"
+        when "American Express"
+          @card_src = "cards/amex.png"
+        when "Diners Club"
+          @card_src = "cards/diners.png"
+        when "Discover"
+          @card_src = "cards/discover.png"
+        end
       end
+    else
+      redirect_to items_path
     end
   end
 
   def new
-    @@previous_page = request.referrer
+    # 直打ちでcards/newに移動できないようにする（直打ちはrequest.referrer = nil）
+    previous_page2 = request.referrer
+    if previous_page2.blank?
+      redirect_to cards_path
+    end
   end
 
   def pay
@@ -43,7 +52,11 @@ class CardsController < ApplicationController
       amount: 50, #支払い金額
       customer: card.customer_id, #支払うユーザのpayjp顧客ID
       currency: 'jpy', #通貨の指定
-    )       
+    )
+
+    @item_buyer = Item.find(params[:id])
+    @item_buyer.update( buyer_id: current_user.id)
+
     redirect_to purchase_done_items_path
  
   end
@@ -59,11 +72,14 @@ class CardsController < ApplicationController
       customer_id: customer.id,
       card_id: customer.default_card
     )
-    if @@previous_page.include?("purchase")
-      @card.save ? (redirect_to @@previous_page) : (render :new)
-    elsif @@previous_page2.include?("purchase")
-      @card.save ? (redirect_to @@previous_page2) : (render :new)
+
+    # カード登録の直前にいたページ（商品購入画面orマイページ）に戻る
+    if @@previous_page.blank?
+      redirect_to cards_path
+    else
+      @card.save ? (redirect_to @@previous_page) : (render :index)
     end
+
   end
 
   def destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,8 +8,8 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @item.images.new
-
   end
+  
   def get_category_children
     @category_children = Category.find(params[:parent_id]).children
   end

--- a/spec/controllers/cards_controller_spec.rb
+++ b/spec/controllers/cards_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe CardsController do
+  describe 'GET #index' do
+    it "登録カードの情報を表示" do
+      context 'ログイン時' do
+        before do
+          login user
+        end
+      
+      
+    end
+
+    it "ログインしていない時、トップページを表示" do
+    end
+  end
+
+  describe 'GET #new' do
+    it "直接アクセスする時、登録カードの情報を表示" do
+    end
+
+    it "すでにカードが登録されている時、登録カードの情報を表示" do
+    end
+
+    it "ログインしていない時、トップページを表示" do
+    end
+  end
+
+  describe 'post #create' do
+    it "カード番号が不正の時、保存されない" do
+    end
+
+    it "カード期限が過去の時、保存されない" do
+    end
+
+    it "セキュリティ番号が不正な時、保存されない" do
+    end
+
+    it "登録完了後、登録画面の直線にいた画面に戻る" do
+    end
+  end
+
+end

--- a/spec/factories/credit_cards.rb
+++ b/spec/factories/credit_cards.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :credit_card do  
+    id   {1}
+    customer_id   {"cus_ca9d1d98900ec1f2595aebefd9a6"}
+    card_id       {"car_a96c76b044d7ae21439d7b9840b7"}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
     email             {"kkk@gmail.com"}
     password          {"00000000"}  
     encrypted_password{"00000000"}
-    last_name       {"sasaki"}
-    first_name        {"goro"}
-    last_name_kana  {"sasaki"}
-    first_name_kana   {"goro"}
+    last_name       {"田中"}
+    first_name        {"太郎"}
+    last_name_kana  {"タナカ"}
+    first_name_kana   {"タロウ"}
     birthday         {"1990-08-24"}
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include ControllerMacros, type: :controller
   
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,6 @@
+module ControllerMacros
+  def login(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end

--- a/spec/support/payjp_mock.rb
+++ b/spec/support/payjp_mock.rb
@@ -1,0 +1,49 @@
+module PayjpMock
+  def self.prepare_customer_information # Payjp::Customerのレスポンスモック
+    {
+      "id": "cus_ca9d1d98900ec1f2595aebefd9a6",
+      "cards": {
+        "count":1,
+        "data":[{
+          "id":"car_a96c76b044d7ae21439d7b9840b7",
+          "address_city":nil,
+          "address_line1":nil,
+          "address_line2":nil,
+          "address_state":nil,
+          "address_zip":nil,
+          "address_zip_check":"unchecked",
+          "brand":"Visa",
+          "country":nil,
+          "created":1578830630,
+          "customer":"cus_ca9d1d98900ec1f2595aebefd9a6",
+          "cvc_check":"passed",
+          "exp_month":12,
+          "exp_year":2020,
+          "fingerprint":"e1d8225886e3a7211127df751c86787f",
+          "last4":"4242",
+          "livemode":false,
+          "metadata":{user_id:1},
+          "name":nil,
+          "object":"card"
+          }],
+          "has_more":false,
+          "object":"list",
+          "url":"/v1/customers/cus_ca9d1d98900ec1f2595aebefd9a6/cards"
+        },
+      "created": 1578830631,
+      "default_card": "car_a96c76b044d7ae21439d7b9840b7",
+      "description": nil,
+      "email": nil,
+      "livemode": false,
+      "metadata": {},
+      "object": "customer",
+      "subscriptions": {
+        "count":0,
+        "data":[],
+        "has_more":false,
+        "object":"list",
+        "url":"/v1/customers/cus_ca9d1d98900ec1f2595aebefd9a6/subscriptions"
+      }
+    }
+  end
+end


### PR DESCRIPTION
## What
商品購入に関する、以下の機能を確認するテストを作成。
- ログイン有無でのカード登録の画像表示
- カード登録機能の顧客データ保存

また、カード登録画面へ直打ちしても飛べない等のエラーハンドリングを追加。

## Why
カード登録の確認とエラーハンドリングは、セキュリティ上重要であるため。

## Note
現状のコードでテストを実行すると、「5 examples, 1 failure」となります。
コード内のコメントにも記載しましたが、これはPayjpモックはハッシュでデータ生成、実際のPayjpはインスタンスでデータ生成されているためです。
このテストを確認するには、一時的にcards_controllerのcreateアクションの記述を変更する必要があります。
（例：current_user.id => current_user[:id]）
※メンターさんと相談したところ、「このコードに関してはこれで問題ない」との結論となりました。