### PR TITLE
itemsテーブルtrading_statusカラム追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'ancestry'
 gem 'payjp'
 gem 'rails-i18n'
 gem "gretel"
+gem 'enum_help'
 
 group :production do
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     diff-lcs (1.4.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     excon (0.75.0)
@@ -406,6 +408,7 @@ DEPENDENCIES
   devise
   devise-i18n
   devise-i18n-views
+  enum_help
   factory_bot_rails
   faker (~> 2.8)
   fog-aws

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,4 +32,6 @@ class Item < ApplicationRecord
       end
   end
   
+  enum trading_status: { exhibiting: 0, duringTrading: 1, transacted: 2 }
+
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  enums:
+    item:
+      trading_status:
+        exhibiting: "出品中"
+        duringTrading: "取引中"
+        transacted: "取引済"
+  activerecord:

--- a/db/migrate/20200716020526_add_trading_status_to_items.rb
+++ b/db/migrate/20200716020526_add_trading_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddTradingStatusToItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :trading_status, :integer, null: false
+  end
+end


### PR DESCRIPTION
# what
ターミナルからrails generate migrationを行いitemsテーブルにenumを用いる為、カラム型にinteger、オプションにnull: fasleを指定しtrading_statusカラムを追加した。
itemモデル内にenumにてtrading_statusを定義した。

# why
本機能は商品購入済なのか売却済なのかを判断する際に使用する為。