### PR TITLE
itemテーブルからtrading_statusカラム削除

### DIFF
--- a/db/migrate/20200718064649_remove_trading_status_from_items.rb
+++ b/db/migrate/20200718064649_remove_trading_status_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveTradingStatusFromItems < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :items, :trading_status, :integer, null: false
+  end
+end


### PR DESCRIPTION
# what
itemテーブルに追加したtrading_statusカラムを削除した。

# why
取引の状態を管理する為にカラムを追加したが、buyer_idとseller_idで出品中、取引中、取引済を簡易的に
管理できることがわかった為。