### PR TITLE
パンくずリスト(ユーザー取り消し)

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,4 @@
 =render partial: 'items/Toppage-header' 
-- breadcrumb :user
-= render "layouts/breadcrumbs"
 
 .mypage
   =render partial: 'users/side-bar'


### PR DESCRIPTION
# what
マイページのパンくずリストの削除。

# why
ローカルでエラーが出た為。