### PR TITLE
検索ページリンク修正

### DIFF
--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -15,7 +15,7 @@
       %ul.Toppage-header__content__bottom__button__left-menu
         %li.Toppage-header__content__bottom__button__left-menu__category-list 
           .categories
-            = link_to "categories", class: "category__search search__btn" do
+            = link_to categories_path, class: "category__search search__btn" do
               カテゴリー
             %ul.category__parent.category__list
               - @parents.each do |parent|


### PR DESCRIPTION
# what
検索ページのヘッダー部にあるカテゴリーのリンク修正。

# why
ページ遷移でエラーが出た為。